### PR TITLE
Fix GUI relative imports

### DIFF
--- a/app/gui/main_window.py
+++ b/app/gui/main_window.py
@@ -9,8 +9,8 @@
 from pathlib import Path
 
 import dearpygui.dearpygui as dpg
-from utils.settings import load_settings
-from simulation import SimulationEngine
+from ..utils.settings import load_settings
+from ..simulation import SimulationEngine
 
 import math
 
@@ -108,7 +108,7 @@ def launch_app(app_root: Path) -> None:
     dpg.show_viewport()
     dpg.render_dearpygui_frame()
 
-    from platform.window_style import apply_dark_titlebar_and_icon
+    from ..platform.window_style import apply_dark_titlebar_and_icon
 
     icon_path = (app_root / "resources" / "icon" / "reefcraft.ico").resolve()
     apply_dark_titlebar_and_icon("Reefcraft", icon_path)

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@
 
 from pathlib import Path
 
-from gui.main_window import launch_app
+from .gui.main_window import launch_app
 
 APP_ROOT = Path(__file__).resolve().parent  # → reefcraft/app
 


### PR DESCRIPTION
## Summary
- fix incorrect absolute imports in app modules
- update GUI to use package-relative paths

## Testing
- `pytest -q`
- `python -m app.main` *(fails: Glfw Error 65544)*

------
https://chatgpt.com/codex/tasks/task_e_6862e0abffd883279111e706086f6622