### PR TITLE
Fix ruff errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = [ "hatchling" ]
 
 [project]
 name = "reefcraft"
@@ -18,10 +18,11 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = [ "src/myproject" ]
+packages = [ "src/reefcraft" ]
 
 dependencies = [
   "attrs>=25.3.0",
@@ -38,7 +39,6 @@ dependencies = [
   "taichi>=1.7.3",
   "wheel>=0.45.1",
 ]
-
 
 [tool.ruff]
 line-length = 160 # Allow longer source lines than the default 88 chars
@@ -84,10 +84,8 @@ testpaths = [
 # Add coverage configuration for pytest and coverage tools
 
 [tool.coverage.run]
-branch = true # Enable branch coverage analysis
-source = [
-  "app",
-]
+branch = true            # Enable branch coverage analysis
+source = [ "reefcraft" ]
 
 [tool.coverage.report]
 show_missing = true # Show missing lines in the coverage report

--- a/src/reefcraft/__init__.py
+++ b/src/reefcraft/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for the Reefcraft project."""

--- a/src/reefcraft/gui/__init__.py
+++ b/src/reefcraft/gui/__init__.py
@@ -1,0 +1,1 @@
+"""Graphical user interface components for Reefcraft."""

--- a/src/reefcraft/sim/engine.py
+++ b/src/reefcraft/sim/engine.py
@@ -4,6 +4,8 @@
 # Licensed under the MIT License. See the LICENSE file for details.
 # -----------------------------------------------------------------------------
 
+"""Simple simulation engine used for driving updates."""
+
 from __future__ import annotations
 
 from .timer import Timer
@@ -13,15 +15,19 @@ class Engine:
     """A thin wrapper that controls a :class:`Timer`."""
 
     def __init__(self) -> None:
+        """Initialize the engine with a new :class:`Timer`."""
         self.timer = Timer()
 
     def start(self) -> None:
+        """Start or resume the timer."""
         self.timer.start()
 
     def pause(self) -> None:
+        """Pause the timer."""
         self.timer.pause()
 
     def reset(self) -> None:
+        """Reset the timer to the initial state."""
         self.timer.reset()
 
     def update(self) -> None:
@@ -29,4 +35,5 @@ class Engine:
         pass
 
     def get_time(self) -> float:
+        """Return the current simulation time."""
         return self.timer.time

--- a/src/reefcraft/sim/timer.py
+++ b/src/reefcraft/sim/timer.py
@@ -4,6 +4,8 @@
 # Licensed under the MIT License. See the LICENSE file for details.
 # -----------------------------------------------------------------------------
 
+"""Utility class for tracking elapsed simulation time."""
+
 from __future__ import annotations
 
 import time
@@ -13,6 +15,7 @@ class Timer:
     """A simple wrapper around ``time.perf_counter``."""
 
     def __init__(self) -> None:
+        """Create a new timer in the paused state."""
         self._start = time.perf_counter()
         self._elapsed = 0.0
         self._paused = True

--- a/src/reefcraft/utils/__init__.py
+++ b/src/reefcraft/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers used throughout the Reefcraft project."""

--- a/src/reefcraft/utils/settings.py
+++ b/src/reefcraft/utils/settings.py
@@ -8,6 +8,7 @@
 
 
 def load_settings() -> dict:
+    """Return default configuration values for the application."""
     return {
         "theme": "dark",
         "default_growth_rate": 1.0,

--- a/src/reefcraft/utils/window_style.py
+++ b/src/reefcraft/utils/window_style.py
@@ -4,17 +4,19 @@
 # Licensed under the MIT License. See the LICENSE file for details.
 # -----------------------------------------------------------------------------
 
+"""Helpers for customizing window appearance on different platforms."""
+
 import sys
 
 if sys.platform == "win32":
     import ctypes
     from ctypes import wintypes
     from pathlib import Path
-    from typing import Union
 
     # import dearpygui.dearpygui as gui
 
     def apply_dark_titlebar_and_icon(window_title: str, icon_path: str | Path) -> None:
+        """Apply a dark title bar and icon to the window if possible."""
         icon_path = Path(icon_path)
 
         hwnd = ctypes.windll.user32.FindWindowW(None, window_title)
@@ -51,4 +53,5 @@ if sys.platform == "win32":
 else:
 
     def apply_dark_titlebar_and_icon(window_title: str, icon_path: str) -> None:
+        """Stub implementation for non-Windows platforms."""
         pass

--- a/tests/python/test_reefcraft.py
+++ b/tests/python/test_reefcraft.py
@@ -2,10 +2,10 @@ import sys
 import time
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 
-from app.sim.engine import Engine
-from app.sim.timer import Timer
+from reefcraft.sim.engine import Engine
+from reefcraft.sim.timer import Timer
 
 
 def test_timer_pause_and_resume() -> None:


### PR DESCRIPTION
## Summary
- add missing docstrings
- remove unused import in window style helper
- use new package name in tests and pyproject

## Testing
- `ruff check src/reefcraft tests`
- `pre-commit run --files pyproject.toml tests/python/test_reefcraft.py src/reefcraft/__init__.py src/reefcraft/gui/__init__.py src/reefcraft/sim/engine.py src/reefcraft/sim/timer.py src/reefcraft/utils/__init__.py src/reefcraft/utils/settings.py src/reefcraft/utils/window_style.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672cb882308331a38c18b42eab8d7a