### PR TITLE
Add GGUI panel

### DIFF
--- a/src/reefcraft/gui/__init__.py
+++ b/src/reefcraft/gui/__init__.py
@@ -1,5 +1,6 @@
 """Graphical user interface components for Reefcraft."""
 
+from .panel import Panel, Section
 from .window import Window
 
-__all__ = ["Window"]
+__all__ = ["Window", "Panel", "Section"]

--- a/src/reefcraft/gui/panel.py
+++ b/src/reefcraft/gui/panel.py
@@ -1,0 +1,56 @@
+"""UI Panel overlay using Taichi GGUI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints
+    from collections.abc import Callable
+
+    import taichi as ti
+
+
+class Section:
+    """A collapsible section inside a :class:`Panel`."""
+
+    def __init__(self, title: str, builder: Callable[[ti.ui.Gui], None]) -> None:
+        """Create a new section.
+
+        Args:
+            title: Header label for the section.
+            builder: Callback used to populate the section's widgets.
+        """
+        self.title = title
+        self.builder = builder
+        self.open = True
+
+    def draw(self, gui: ti.ui.Gui) -> None:
+        """Render this section using ``gui``."""
+        self.open = gui.checkbox(self.title, self.open)
+        if self.open:
+            self.builder(gui)
+
+
+class Panel:
+    """Fixed side panel that holds collapsible sections."""
+
+    def __init__(self, width: int = 300, margin: int = 10) -> None:
+        """Initialize the panel with width and margin."""
+        self.width = width
+        self.margin = margin
+        self.sections: list[Section] = []
+
+    def register(self, section: Section) -> None:
+        """Add a section to the panel."""
+        self.sections.append(section)
+
+    def draw(self, window: ti.ui.Window, gui: ti.ui.Gui) -> None:
+        """Render the panel and its sections."""
+        win_w, win_h = window.get_window_shape()
+        x = (win_w - self.margin - self.width) / win_w
+        y = self.margin / win_h
+        w = self.width / win_w
+        h = (win_h - 2 * self.margin) / win_h
+        with gui.sub_window("Panel", x, y, w, h):
+            for section in self.sections:
+                section.draw(gui)

--- a/src/reefcraft/gui/window.py
+++ b/src/reefcraft/gui/window.py
@@ -4,13 +4,15 @@
 # Licensed under the MIT License. See the LICENSE file for details.
 # -----------------------------------------------------------------------------
 
-"""Defines the main GUI layout using Taichi."""
+"""Defines the main GUI layout using Taichi's GGUI."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 import taichi as ti
+
+from .panel import Panel, Section
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -19,14 +21,15 @@ if TYPE_CHECKING:
 
 
 class Window:
-    """Encapsulate the Taichi GUI window."""
+    """Encapsulate the Taichi window and overlay UI panel."""
 
     def __init__(self, engine: Engine, app_root: Path) -> None:
-        """Initialize the window and related Taichi state."""
+        """Initialize the window and GUI state."""
         self.engine = engine
 
-        ti.init(arch=ti.gpu)
-        self.window = ti.ui.Window("Reefcraft", res=(1280, 1080))
+        ti.init(arch=ti.vulkan)
+        self.window = ti.ui.Window("Reefcraft", res=(1280, 1080), vsync=True)
+        self.canvas = self.window.get_canvas()
         self.gui = self.window.get_gui()
 
         from ..utils.window_style import apply_dark_titlebar_and_icon
@@ -34,20 +37,39 @@ class Window:
         icon_path = (app_root / "resources" / "icon" / "reefcraft.ico").resolve()
         apply_dark_titlebar_and_icon("Reefcraft", icon_path)
 
+        self.panel = Panel(width=300, margin=10)
+        self._register_demo_sections()
+
+    def _register_demo_sections(self) -> None:
+        """Register example sections for demonstration."""
+
+        def coral_growth(gui: ti.ui.Gui) -> None:
+            self.growth_rate = getattr(self, "growth_rate", 1.0)
+            self.growth_rate = gui.slider_float("Growth Rate", self.growth_rate, 0.0, 2.0)
+            self.complexity = getattr(self, "complexity", 0.5)
+            self.complexity = gui.slider_float("Complexity", self.complexity, 0.0, 1.0)
+            if gui.button("Apply"):
+                print("[DEBUG] Apply coral growth")
+
+        def environment(gui: ti.ui.Gui) -> None:
+            self.temperature = getattr(self, "temperature", 24.0)
+            self.temperature = gui.slider_float("Water Temp", self.temperature, 10.0, 30.0)
+            self.light = getattr(self, "light", 0.8)
+            self.light = gui.slider_float("Light", self.light, 0.0, 1.0)
+            if gui.button("Reset Environment"):
+                print("[DEBUG] Reset environment")
+
+        self.panel.register(Section("Coral Growth", coral_growth))
+        self.panel.register(Section("Environment", environment))
+
     @property
     def running(self) -> bool:
         """Return ``True`` if the underlying Taichi window is still open."""
         return self.window.running
 
     def update(self) -> None:
-        """Update GUI elements for one frame."""
-        self.gui.text("Simulation Controls")
-        if self.gui.button("Start"):
-            self.engine.start()
-        if self.gui.button("Pause"):
-            self.engine.pause()
-        if self.gui.button("Reset"):
-            self.engine.reset()
-
-        self.gui.text(f"Time: {self.engine.get_time():.3f}")
+        """Render one frame of the simulation and overlay UI."""
+        self.canvas.clear((0.0, 0.0, 0.0))
+        # Simulation visualization would be drawn to the canvas here
+        self.panel.draw(self.window, self.gui)
         self.window.show()

--- a/src/reefcraft/gui/window.py
+++ b/src/reefcraft/gui/window.py
@@ -38,23 +38,32 @@ class Window:
         apply_dark_titlebar_and_icon("Reefcraft", icon_path)
 
         self.panel = Panel(width=300, margin=10)
+
+        # Default values for demo section sliders
+        self.growth_rate = 1.0
+        self.complexity = 0.5
+        self.temperature = 24.0
+        self.light = 0.8
+
         self._register_demo_sections()
 
     def _register_demo_sections(self) -> None:
         """Register example sections for demonstration."""
 
         def coral_growth(gui: ti.ui.Gui) -> None:
-            self.growth_rate = getattr(self, "growth_rate", 1.0)
-            self.growth_rate = gui.slider_float("Growth Rate", self.growth_rate, 0.0, 2.0)
-            self.complexity = getattr(self, "complexity", 0.5)
-            self.complexity = gui.slider_float("Complexity", self.complexity, 0.0, 1.0)
+            self.growth_rate = gui.slider_float(
+                "Growth Rate", self.growth_rate, 0.0, 2.0
+            )
+            self.complexity = gui.slider_float(
+                "Complexity", self.complexity, 0.0, 1.0
+            )
             if gui.button("Apply"):
                 print("[DEBUG] Apply coral growth")
 
         def environment(gui: ti.ui.Gui) -> None:
-            self.temperature = getattr(self, "temperature", 24.0)
-            self.temperature = gui.slider_float("Water Temp", self.temperature, 10.0, 30.0)
-            self.light = getattr(self, "light", 0.8)
+            self.temperature = gui.slider_float(
+                "Water Temp", self.temperature, 10.0, 30.0
+            )
             self.light = gui.slider_float("Light", self.light, 0.0, 1.0)
             if gui.button("Reset Environment"):
                 print("[DEBUG] Reset environment")
@@ -69,7 +78,7 @@ class Window:
 
     def update(self) -> None:
         """Render one frame of the simulation and overlay UI."""
-        self.canvas.clear((0.0, 0.0, 0.0))
+        self.canvas.set_background_color((0.0, 0.0, 0.0))
         # Simulation visualization would be drawn to the canvas here
         self.panel.draw(self.window, self.gui)
         self.window.show()

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -106,7 +106,7 @@ def test_window_update_renders_panel() -> None:
 
         win.panel = MagicMock()
         win.update()
-        dummy_canvas.clear.assert_called_once()
+        dummy_canvas.set_background_color.assert_called_once_with((0.0, 0.0, 0.0))
         win.panel.draw.assert_called_once_with(dummy_window, dummy_gui)
         dummy_window.show.assert_called_once()
 

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -1,0 +1,112 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+if "taichi" not in sys.modules:
+    ui_stub = types.SimpleNamespace(Window=object, Gui=object)
+    ti_stub = types.SimpleNamespace(ui=ui_stub, vulkan="vulkan", init=lambda arch=None: None)
+    sys.modules["taichi"] = ti_stub
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from reefcraft.gui.panel import Panel, Section
+from reefcraft.gui.window import Window
+from reefcraft.sim.engine import Engine
+
+
+def test_section_builder_called_when_open() -> None:
+    called = []
+
+    def builder(gui: object) -> None:
+        called.append(True)
+
+    class DummyGui:
+        def __init__(self, checked: bool) -> None:
+            self.checked = checked
+
+        def checkbox(self, title: str, state: bool) -> bool:  # noqa: D401 - simple stub
+            return self.checked
+
+    gui = DummyGui(True)
+    sec = Section("Test", builder)
+    sec.draw(gui)
+    assert sec.open is True
+    assert called == [True]
+
+    gui.checked = False
+    sec.draw(gui)
+    assert sec.open is False
+    assert called == [True]
+
+
+def test_panel_draw_calls_sections() -> None:
+    class DummyWindow:
+        def get_window_shape(self) -> tuple[int, int]:
+            return (800, 600)
+
+    class DummyGui:
+        def __init__(self) -> None:
+            self.sub_windows: list[tuple[str, float, float, float, float]] = []
+
+        def __call__(self) -> "DummyGui":  # type: ignore[override]
+            return self
+
+        def checkbox(self, title: str, value: bool) -> bool:
+            return value
+
+        from contextlib import AbstractContextManager, contextmanager
+
+        @contextmanager
+        def sub_window(self, title: str, x: float, y: float, w: float, h: float) -> AbstractContextManager["DummyGui"]:
+            self.sub_windows.append((title, x, y, w, h))
+            yield self
+
+    gui = DummyGui()
+    window = DummyWindow()
+    panel = Panel(width=300, margin=10)
+
+    class DummySection:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def draw(self, g: DummyGui) -> None:
+            self.calls += 1
+
+    sec = DummySection()
+    panel.register(sec)
+    panel.draw(window, gui)
+
+    assert sec.calls == 1
+    assert len(gui.sub_windows) == 1
+    _, x, y, w, h = gui.sub_windows[0]
+    assert x == (800 - 10 - 300) / 800
+    assert y == 10 / 600
+    assert w == 300 / 800
+    assert h == (600 - 20) / 600
+
+
+def test_window_update_renders_panel() -> None:
+    engine = Engine()
+
+    with patch("reefcraft.gui.window.ti") as mti, patch(
+        "reefcraft.utils.window_style.apply_dark_titlebar_and_icon"
+    ):
+        dummy_window = MagicMock()
+        dummy_canvas = MagicMock()
+        dummy_gui = MagicMock()
+        mti.vulkan = "vulkan"
+        mti.init.return_value = None
+        mti.ui.Window.return_value = dummy_window
+        dummy_window.get_canvas.return_value = dummy_canvas
+        dummy_window.get_gui.return_value = dummy_gui
+
+        win = Window(engine, Path())
+        assert len(win.panel.sections) == 2
+
+        win.panel = MagicMock()
+        win.update()
+        dummy_canvas.clear.assert_called_once()
+        win.panel.draw.assert_called_once_with(dummy_window, dummy_gui)
+        dummy_window.show.assert_called_once()
+


### PR DESCRIPTION
## Summary
- implement `Panel` and `Section` classes for overlay UI
- rework `Window` to use Taichi's Vulkan backend
- expose new components via `gui.__init__`

## Testing
- `ruff check --fix src/reefcraft/gui/panel.py src/reefcraft/gui/window.py src/reefcraft/gui/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bf2ce3f483319fa725cf8a550171