### PR TITLE
Add Volume class and render voxels

### DIFF
--- a/src/reefcraft/gui/window.py
+++ b/src/reefcraft/gui/window.py
@@ -31,6 +31,8 @@ class Window:
         self.window = ti.ui.Window("Reefcraft", res=(1280, 1080), vsync=True)
         self.canvas = self.window.get_canvas()
         self.gui = self.window.get_gui()
+        self.scene = ti.ui.Scene()
+        self.camera = ti.ui.make_camera()
 
         from ..utils.window_style import apply_dark_titlebar_and_icon
 
@@ -79,6 +81,13 @@ class Window:
     def update(self) -> None:
         """Render one frame of the simulation and overlay UI."""
         self.canvas.set_background_color((0.0, 0.0, 0.0))
-        # Simulation visualization would be drawn to the canvas here
+
+        self.camera.position(0.5, 0.5, 2.0)
+        self.camera.lookat(0.5, 0.5, 0.5)
+        self.scene.set_camera(self.camera)
+        self.scene.ambient_light((0.5, 0.5, 0.5))
+        self.engine.volume.render(self.scene)
+        self.canvas.scene(self.scene)
+
         self.panel.draw(self.window, self.gui)
         self.window.show()

--- a/src/reefcraft/gui/window.py
+++ b/src/reefcraft/gui/window.py
@@ -27,7 +27,6 @@ class Window:
         """Initialize the window and GUI state."""
         self.engine = engine
 
-        ti.init(arch=ti.vulkan)
         self.window = ti.ui.Window("Reefcraft", res=(1280, 1080), vsync=True)
         self.canvas = self.window.get_canvas()
         self.gui = self.window.get_gui()

--- a/src/reefcraft/sim/__init__.py
+++ b/src/reefcraft/sim/__init__.py
@@ -2,5 +2,6 @@
 
 from .engine import Engine
 from .timer import Timer
+from .volume import Volume
 
-__all__ = ["Engine", "Timer"]
+__all__ = ["Engine", "Timer", "Volume"]

--- a/src/reefcraft/sim/engine.py
+++ b/src/reefcraft/sim/engine.py
@@ -9,14 +9,16 @@
 from __future__ import annotations
 
 from .timer import Timer
+from .volume import Volume
 
 
 class Engine:
     """A thin wrapper that controls a :class:`Timer`."""
 
     def __init__(self) -> None:
-        """Initialize the engine with a new :class:`Timer`."""
+        """Initialize the engine state."""
         self.timer = Timer()
+        self.volume = Volume()
 
     def start(self) -> None:
         """Start or resume the timer."""

--- a/src/reefcraft/sim/engine.py
+++ b/src/reefcraft/sim/engine.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+import taichi as ti
+
 from .timer import Timer
 from .volume import Volume
 
@@ -17,6 +19,8 @@ class Engine:
 
     def __init__(self) -> None:
         """Initialize the engine state."""
+        if not getattr(ti, "is_initialized", lambda: False)():
+            ti.init(arch=ti.vulkan)
         self.timer = Timer()
         self.volume = Volume()
 

--- a/src/reefcraft/sim/volume.py
+++ b/src/reefcraft/sim/volume.py
@@ -19,14 +19,13 @@ class Volume:
 
         Args:
             active_region: Size of the region to initialize with test data.
-                The full volume is ``1000^3`` voxels but only a small region is
-                allocated for visualization during testing.
+                The logical volume is ``1000^3`` voxels, but only an
+                ``active_region`` cube is allocated for this preview to avoid
+                excessive memory use.
         """
         self.resolution = 1000
         self.active = active_region
-        self.data = ti.Vector.field(3, dtype=ti.f32)
-        block = 8
-        ti.root.pointer(ti.ijk, self.resolution // block).dense(ti.ijk, block).place(self.data)
+        self.data = ti.Vector.field(3, dtype=ti.f32, shape=(self.active, self.active, self.active))
         self.coords = ti.Vector.field(3, dtype=ti.f32, shape=self.active ** 3)
         self.colors = ti.Vector.field(3, dtype=ti.f32, shape=self.active ** 3)
         self._fill_test_pattern()

--- a/src/reefcraft/sim/volume.py
+++ b/src/reefcraft/sim/volume.py
@@ -1,0 +1,44 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2025 The Reefcraft Project.
+#
+# Licensed under the MIT License. See the LICENSE file for details.
+# -----------------------------------------------------------------------------
+
+"""Voxel grid representing a cubic meter of water."""
+
+from __future__ import annotations
+
+import taichi as ti
+
+
+class Volume:
+    """A sparse voxel volume at millimeter resolution."""
+
+    def __init__(self, active_region: int = 32) -> None:
+        """Create the voxel grid.
+
+        Args:
+            active_region: Size of the region to initialize with test data.
+                The full volume is ``1000^3`` voxels but only a small region is
+                allocated for visualization during testing.
+        """
+        self.resolution = 1000
+        self.active = active_region
+        self.data = ti.Vector.field(3, dtype=ti.f32)
+        block = 8
+        ti.root.pointer(ti.ijk, self.resolution // block).dense(ti.ijk, block).place(self.data)
+        self.coords = ti.Vector.field(3, dtype=ti.f32, shape=self.active ** 3)
+        self.colors = ti.Vector.field(3, dtype=ti.f32, shape=self.active ** 3)
+        self._fill_test_pattern()
+
+    @ti.kernel
+    def _fill_test_pattern(self) -> None:
+        for i, j, k in ti.ndrange(self.active, self.active, self.active):
+            idx = i * self.active * self.active + j * self.active + k
+            self.data[i, j, k] = ti.Vector([1.0, 1.0, 1.0])
+            self.coords[idx] = ti.Vector([i, j, k]) / self.resolution
+            self.colors[idx] = ti.Vector([i, j, k]) / self.active
+
+    def render(self, scene: ti.ui.Scene) -> None:
+        """Draw the voxel test pattern to ``scene``."""
+        scene.particles(self.coords, radius=0.002, per_vertex_color=self.colors)

--- a/src/reefcraft/sim/volume.py
+++ b/src/reefcraft/sim/volume.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import taichi as ti
 
 
+@ti.data_oriented
 class Volume:
     """A sparse voxel volume at millimeter resolution."""
 

--- a/src/reefcraft/sim/volume.py
+++ b/src/reefcraft/sim/volume.py
@@ -32,7 +32,7 @@ class Volume:
         self._fill_test_pattern()
 
     @ti.kernel
-    def _fill_test_pattern(self) -> ti.types.void:
+    def _fill_test_pattern(self) -> None:
         for i, j, k in ti.ndrange(self.active, self.active, self.active):
             idx = i * self.active * self.active + j * self.active + k
             self.data[i, j, k] = ti.Vector([1.0, 1.0, 1.0])

--- a/src/reefcraft/sim/volume.py
+++ b/src/reefcraft/sim/volume.py
@@ -32,7 +32,7 @@ class Volume:
         self._fill_test_pattern()
 
     @ti.kernel
-    def _fill_test_pattern(self) -> None:
+    def _fill_test_pattern(self) -> ti.types.void:
         for i, j, k in ti.ndrange(self.active, self.active, self.active):
             idx = i * self.active * self.active + j * self.active + k
             self.data[i, j, k] = ti.Vector([1.0, 1.0, 1.0])

--- a/src/reefcraft/sim/volume.py
+++ b/src/reefcraft/sim/volume.py
@@ -32,7 +32,7 @@ class Volume:
         self._fill_test_pattern()
 
     @ti.kernel
-    def _fill_test_pattern(self) -> None:
+    def _fill_test_pattern(self):  # noqa: ANN202
         for i, j, k in ti.ndrange(self.active, self.active, self.active):
             idx = i * self.active * self.active + j * self.active + k
             self.data[i, j, k] = ti.Vector([1.0, 1.0, 1.0])

--- a/tests/python/test_a_volume_taichi.py
+++ b/tests/python/test_a_volume_taichi.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import numpy as np
+import taichi as ti
+
+# Initialize Taichi on CPU for deterministic behavior
+# Calling ti.init multiple times is safe
+if not getattr(ti, "_initialized", False):
+    from contextlib import suppress
+
+    with suppress(Exception):
+        ti.init(arch=ti.cpu)
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+import importlib
+
+
+def reload_volume():  # noqa: ANN201
+    from reefcraft import sim
+
+    return importlib.reload(sim.volume).Volume
+
+
+def test_fill_test_pattern_values() -> None:
+    Volume = reload_volume()
+    vol = Volume(active_region=2)
+    assert vol.data.shape == (2, 2, 2)
+    assert vol.coords.shape == (8,)
+    assert vol.colors.shape == (8,)
+
+    assert np.allclose(vol.data[0, 0, 0], [1.0, 1.0, 1.0])
+    idx = 1 * vol.active * vol.active + 0 * vol.active + 1
+    expected_coord = np.array([1, 0, 1]) / vol.resolution
+    assert np.allclose(vol.coords[idx], expected_coord)
+    expected_color = np.array([1, 0, 1]) / vol.active
+    assert np.allclose(vol.colors[idx], expected_color)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -4,8 +4,40 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 if "taichi" not in sys.modules:
-    ui_stub = types.SimpleNamespace(Window=object, Gui=object)
-    ti_stub = types.SimpleNamespace(ui=ui_stub, vulkan="vulkan", init=lambda arch=None: None)
+    def fake_field(*args: object, shape: tuple[int, ...] | None = None, **kwargs: object) -> object:
+        class Dummy:
+            def __init__(self, shape: tuple[int, ...] | None) -> None:
+                self.shape = shape
+
+        return Dummy(shape)
+
+    def ndrange(*sizes: int) -> list[tuple[int, int, int]]:
+        result = []
+        for i in range(sizes[0]):
+            for j in range(sizes[1]):
+                for k in range(sizes[2]):
+                    result.append((i, j, k))
+        return result
+
+    ui_stub = types.SimpleNamespace(Window=object, Gui=object, Scene=object, make_camera=lambda: object())
+
+    def vector(values: object | None = None) -> object | None:
+        return values
+
+    vector.field = fake_field
+
+    ti_stub = types.SimpleNamespace(
+        ui=ui_stub,
+        vulkan="vulkan",
+        init=lambda arch=None: None,
+        kernel=lambda f: f,
+        Vector=vector,
+        field=fake_field,
+        f32=0.0,
+        ijk=0,
+        ndrange=ndrange,
+        root=types.SimpleNamespace(pointer=lambda *a, **k: types.SimpleNamespace(dense=lambda *a, **k: types.SimpleNamespace(place=lambda *a, **k: None))),
+    )
     sys.modules["taichi"] = ti_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
@@ -13,6 +45,9 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 from reefcraft.gui.panel import Panel, Section
 from reefcraft.gui.window import Window
 from reefcraft.sim.engine import Engine
+from reefcraft.sim.volume import Volume
+
+Volume._fill_test_pattern = lambda self: None
 
 
 def test_section_builder_called_when_open() -> None:

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -31,6 +31,7 @@ if "taichi" not in sys.modules:
         vulkan="vulkan",
         init=lambda arch=None: None,
         kernel=lambda f: f,
+        data_oriented=lambda cls: cls,
         Vector=vector,
         field=fake_field,
         f32=0.0,

--- a/tests/python/test_reefcraft.py
+++ b/tests/python/test_reefcraft.py
@@ -1,11 +1,52 @@
 import sys
 import time
+import types
 from pathlib import Path
+
+if "taichi" not in sys.modules:
+    def fake_field(*args: object, shape: tuple[int, ...] | None = None, **kwargs: object) -> object:
+        class Dummy:
+            def __init__(self, shape: tuple[int, ...] | None) -> None:
+                self.shape = shape
+
+        return Dummy(shape)
+
+    def ndrange(*sizes: int) -> list[tuple[int, int, int]]:
+        result = []
+        for i in range(sizes[0]):
+            for j in range(sizes[1]):
+                for k in range(sizes[2]):
+                    result.append((i, j, k))
+        return result
+
+    ui_stub = types.SimpleNamespace(Window=object, Gui=object, Scene=object, make_camera=lambda: object())
+
+    def vector(values: object | None = None) -> object | None:
+        return values
+
+    vector.field = fake_field
+
+    ti_stub = types.SimpleNamespace(
+        ui=ui_stub,
+        vulkan="vulkan",
+        init=lambda arch=None: None,
+        kernel=lambda f: f,
+        Vector=vector,
+        field=fake_field,
+        f32=0.0,
+        ijk=0,
+        ndrange=ndrange,
+        root=types.SimpleNamespace(pointer=lambda *a, **k: types.SimpleNamespace(dense=lambda *a, **k: types.SimpleNamespace(place=lambda *a, **k: None))),
+    )
+    sys.modules["taichi"] = ti_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 
 from reefcraft.sim.engine import Engine
 from reefcraft.sim.timer import Timer
+from reefcraft.sim.volume import Volume
+
+Volume._fill_test_pattern = lambda self: None
 
 
 def test_timer_pause_and_resume() -> None:

--- a/tests/python/test_reefcraft.py
+++ b/tests/python/test_reefcraft.py
@@ -31,6 +31,7 @@ if "taichi" not in sys.modules:
         vulkan="vulkan",
         init=lambda arch=None: None,
         kernel=lambda f: f,
+        data_oriented=lambda cls: cls,
         Vector=vector,
         field=fake_field,
         f32=0.0,

--- a/tests/python/test_volume.py
+++ b/tests/python/test_volume.py
@@ -47,5 +47,6 @@ Volume._fill_test_pattern = lambda self: None
 def test_volume_initializes_fields() -> None:
     vol = Volume(active_region=4)
     assert vol.resolution == 1000
+    assert vol.data.shape == (4, 4, 4)
     assert vol.coords.shape == 4 ** 3
 

--- a/tests/python/test_volume.py
+++ b/tests/python/test_volume.py
@@ -1,0 +1,51 @@
+import sys
+import types
+from pathlib import Path
+
+if "taichi" not in sys.modules:
+    ti_stub = types.SimpleNamespace()
+    ti_stub.vulkan = "vulkan"
+    ti_stub.init = lambda arch=None: None
+    ti_stub.kernel = lambda f: f
+
+    def fake_field(*args: object, shape: tuple[int, ...] | None = None, **kwargs: object) -> object:
+        class Dummy:
+            def __init__(self, shape: tuple[int, ...] | None) -> None:
+                self.shape = shape
+
+        return Dummy(shape)
+
+    def ndrange(*sizes: int) -> list[tuple[int, int, int]]:
+        result = []
+        for i in range(sizes[0]):
+            for j in range(sizes[1]):
+                for k in range(sizes[2]):
+                    result.append((i, j, k))
+        return result
+
+    def vector(values: object | None = None) -> object | None:
+        return values
+
+    vector.field = fake_field
+
+    ti_stub.Vector = vector
+    ti_stub.field = fake_field
+    ti_stub.f32 = 0.0
+    ti_stub.ndrange = ndrange
+    ti_stub.ijk = 0
+    ti_stub.root = types.SimpleNamespace(pointer=lambda *a, **k: types.SimpleNamespace(dense=lambda *a, **k: types.SimpleNamespace(place=lambda *a, **k: None)))
+    ti_stub.ui = types.SimpleNamespace(Scene=object, make_camera=lambda: object())
+    sys.modules["taichi"] = ti_stub
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from reefcraft.sim.volume import Volume
+
+Volume._fill_test_pattern = lambda self: None
+
+
+def test_volume_initializes_fields() -> None:
+    vol = Volume(active_region=4)
+    assert vol.resolution == 1000
+    assert vol.coords.shape == 4 ** 3
+

--- a/tests/python/test_volume.py
+++ b/tests/python/test_volume.py
@@ -49,5 +49,5 @@ def test_volume_initializes_fields() -> None:
     vol = Volume(active_region=4)
     assert vol.resolution == 1000
     assert vol.data.shape == (4, 4, 4)
-    assert vol.coords.shape == 4 ** 3
+    assert vol.coords.shape == (4 ** 3,)
 

--- a/tests/python/test_volume.py
+++ b/tests/python/test_volume.py
@@ -7,6 +7,7 @@ if "taichi" not in sys.modules:
     ti_stub.vulkan = "vulkan"
     ti_stub.init = lambda arch=None: None
     ti_stub.kernel = lambda f: f
+    ti_stub.data_oriented = lambda cls: cls
 
     def fake_field(*args: object, shape: tuple[int, ...] | None = None, **kwargs: object) -> object:
         class Dummy:


### PR DESCRIPTION
## Summary
- create `Volume` voxel grid using Taichi fields
- export the new class from `sim`
- instantiate `Volume` in the simulation engine
- render the voxel grid in the main window
- stub Taichi features in tests and cover the new class

## Testing
- `ruff check . --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686af4f87d748331934e9e3c0c81b5eb