### PR TITLE
Refactor SimpleP growth model to use Trimesh mesh

### DIFF
--- a/src/reefcraft/sim/simple_porag.py
+++ b/src/reefcraft/sim/simple_porag.py
@@ -4,27 +4,35 @@
 # Licensed under the MIT License. See the LICENSE file for details.
 # -----------------------------------------------------------------------------
 
-"""Simple PORAG inpired growth model."""
+"""Simple PORAG inspired growth model using :mod:`trimesh` for mesh handling."""
+
+from __future__ import annotations
 
 import numpy as np
+import trimesh
 import warp as wp
-from scipy.spatial import ConvexHull
 
 from reefcraft.sim.state import SimState
 
 
 class SimpleP:
-    """Coral growth simulation with polyps evenly spaced on a hemisphere surface."""
+    """Coral growth simulation with polyps evenly spaced on a hemisphere surface.
+
+    The mesh is managed internally with :class:`trimesh.Trimesh` for convenient
+    geometric queries while Warp arrays are maintained for GPU kernels and for
+    passing data to other parts of the simulation.
+    """
 
     def __init__(
         self,
         sim_state: SimState,
-        grid_shape: tuple = (200, 200, 200),
+        grid_shape: tuple[int, int, int] = (200, 200, 200),
         polyp_spacing: float = 0.5,
         max_time_steps: int = 1000,
         resource_concentration: float = 1.0,
     ) -> None:
-        """Initializes the SimpleP coral growth model with basic parameters and Warp for GPU acceleration."""
+        """Initialize the SimpleP coral growth model."""
+
         self.grid_shape = grid_shape
         self.polyp_spacing = polyp_spacing
         self.max_time_steps = max_time_steps
@@ -33,101 +41,73 @@ class SimpleP:
         self.radius = self.calculate_radius()
 
         self.mesh = self.initialize_polyps()
-        self.normals = wp.zeros((len(self.mesh["vertices"]),), dtype=wp.vec3f)
-
-        # self.launch_mesh_kernel()
+        self.update_wp_arrays()
 
         # Add our new coral to the simulation state
         self.coral_state = sim_state.add_coral()
-        self.coral_state.set_mesh(self.mesh["vertices"], self.mesh["indices"])
+        self.coral_state.set_mesh(self.verts_wp, self.indices_wp)
 
     def calculate_radius(self) -> float:
-        """Calculates the radius of the hemisphere based on the polyp spacing."""
+        """Calculate the radius of the hemisphere based on the polyp spacing."""
+
         num_polyps = 81  # Total polyps on the hemisphere
-        surface_area_per_polyp = self.polyp_spacing**2  # Area occupied by each polyp
-
-        # Total surface area covered by the polyps
+        surface_area_per_polyp = self.polyp_spacing**2
         total_area = num_polyps * surface_area_per_polyp
-
         radius = np.sqrt(total_area / (2 * np.pi))
+        return float(radius)
 
-        return radius
+    def initialize_polyps(self) -> trimesh.Trimesh:
+        """Initialise a hemispherical distribution of polyps as a mesh."""
 
-    def initialize_polyps(self) -> dict:
-        """Initializes the polyps on the hemisphere mesh as a dictionary of Warp arrays.
+        num_polyps = 81
+        vertices = np.zeros((num_polyps, 3), dtype=np.float32)
 
-        Returns:
-        - A dictionary with 'vertices' (wp.array) and 'indices' (wp.array).
-        """
-        num_polyps = 81  # Total number of polyps (vertices)
-        vertices = np.zeros((num_polyps, 3), dtype=np.float32)  # NumPy array for vertices
-
-        # Golden angle for even distribution
         golden_angle = np.pi * (3.0 - np.sqrt(5.0))
-
         for i in range(num_polyps):
-            # Polar angle adjusted for a hemisphere only
-            phi = np.arccos(1 - (i + 0.5) / num_polyps)  # Polar angle in [0, pi/2] for hemisphere
-            theta = golden_angle * i  # Azimuthal angle (0 to 2*pi)
-
-            # Convert spherical to Cartesian coordinates
+            phi = np.arccos(1 - (i + 0.5) / num_polyps)  # hemisphere polar angle
+            theta = golden_angle * i
             x = self.radius * np.sin(phi) * np.cos(theta)
             y = self.radius * np.sin(phi) * np.sin(theta)
             z = self.radius * np.cos(phi)
-
             vertices[i] = [x, y, z]
 
-        # Manually create indices for the hemisphere
-        # Here we are creating triangles by connecting each vertex to the center and its neighbors
-        indices = []
-
-        # Add the base of the hemisphere (a circle at the bottom of the hemisphere)
-        bottom_center = num_polyps - 1  # the last vertex is the center of the base
+        # Construct indices by connecting neighbouring points and a base centre
+        indices: list[list[int]] = []
+        bottom_center = num_polyps - 1
         for i in range(num_polyps - 1):
             indices.append([i, (i + 1) % (num_polyps - 1), bottom_center])
-
-        # Create the upper hemisphere faces (a fan structure)
         for i in range(num_polyps - 1):
-            # Create faces between adjacent points on the surface
-            next_i = (i + 1) % (num_polyps - 1)  # next vertex in the list
-            indices.append([i, next_i, num_polyps - 1])  # Connect the surface vertices to the center
+            next_i = (i + 1) % (num_polyps - 1)
+            indices.append([i, next_i, bottom_center])
 
-        # Convert the vertices and indices to Warp arrays
-        vertices_wp = wp.array(np.array(vertices, dtype=np.float32), dtype=wp.vec3f)
-        indices_wp = wp.array(np.array(indices, dtype=np.int32), dtype=wp.vec3i)
+        return trimesh.Trimesh(vertices=vertices, faces=np.array(indices, dtype=np.int32), process=False)
 
-        return {"vertices": vertices_wp, "indices": indices_wp}
+    # ------------------------------------------------------------------
+    # Mesh/Warp array helpers
+    # ------------------------------------------------------------------
+    def update_wp_arrays(self) -> None:
+        """Update Warp arrays for vertices, indices and normals from the mesh."""
 
-    def update(self, state: SimState) -> None:
-        """Update SimState mesh."""
+        verts_np = self.mesh.vertices.astype(np.float32)
+        faces_np = self.mesh.faces.astype(np.int32)
+        normals_np = self.mesh.vertex_normals.astype(np.float32)
+
+        self.verts_wp = wp.array(verts_np, dtype=wp.vec3f)
+        self.indices_wp = wp.array(faces_np, dtype=wp.vec3i)
+        self.normals_wp = wp.array(normals_np, dtype=wp.vec3f)
+
+    # ------------------------------------------------------------------
+    # Simulation update interface
+    # ------------------------------------------------------------------
+    def update(self, state: SimState) -> None:  # noqa: D401 - Short docstring
+        """Update the SimState mesh."""
+
         self.growth_step()
-        print(f" Verts Type: {type(self.mesh.get('vertices'))}, Indices Type: {type(self.mesh.get('indices'))}")
-        self.coral_state.set_mesh(self.mesh.get("vertices"), self.mesh.get("indices"))
+        self.coral_state.set_mesh(self.verts_wp, self.indices_wp)
 
-    def update_mesh(self, mesh_data: dict) -> None:
-        """Update the mesh with a new set of polyps."""
-        self.mesh = mesh_data
-
-    @wp.kernel
-    def calculate_normals_kernel(vertices: wp.array(dtype=wp.vec3f), normals: wp.array(dtype=wp.vec3f), n: int) -> None:
-        """Kernel to calculate normals for each vertex based on the hemisphere structure."""
-        idx = wp.tid()
-        if idx < n:
-            vertex = vertices[idx]
-            normal = vertex / wp.length(vertex)
-            normals[idx] = normal
-
-    def launch_mesh_kernel(self) -> None:
-        """Launch kernels to initialize mesh and compute normals."""
-        num_polyps = len(self.mesh["vertices"])
-
-        # Ensure the normals are initialized as wp.array with dtype wp.vec3f
-        if self.normals is None:
-            # Allocate normals array with the correct Warp type
-            self.normals = wp.zeros(num_polyps, dtype=wp.vec3f)
-
-        wp.launch(self.calculate_normals_kernel, dim=num_polyps, inputs=[self.mesh["vertices"], self.normals, num_polyps])
-
+    # ------------------------------------------------------------------
+    # Growth logic
+    # ------------------------------------------------------------------
     @wp.kernel
     def growth_kernel(
         vertices: wp.array(dtype=wp.vec3f),
@@ -139,6 +119,7 @@ class SimpleP:
         z_max: float,
     ) -> None:
         """Kernel to update polyp positions based on growth and normal vectors."""
+
         idx = wp.tid()
         if idx < n:
             vertex = vertices[idx]
@@ -147,36 +128,25 @@ class SimpleP:
             z_position = vertex[2]
             resource_at_polyp = resource_concentration * (z_position / z_max)
 
-            # Compute the angle between the normal and the z-axis: THIS NEEDS UPDATE
             angle = wp.acos(wp.dot(normal, wp.vec3(0.0, 0.0, 1.0)) / wp.length(normal))
             angle_deg = wp.degrees(angle)
 
-            # Scale the resource based on convexity
             scale = (360.0 - angle_deg) / 360.0
-
-            # Calculate the final growth amount
             growth = resource_at_polyp * scale
 
-            # Update the growth_amount (apply spacing for movement)
             growth_amount[idx] = growth * spacing
-
-            # Update the polyp's position based on the growth amount and the normal direction
             vertices[idx] += normal * growth_amount[idx]
 
-    def add_polyp(self, new_polyp: tuple) -> None:
-        """Add a new polyp (vertex) to the list of polyps if space allows."""
-        # Check if there’s space for the new polyp based on spacing
-        vertices_np = self.mesh["vertices"].numpy()
-        for vertex in vertices_np:
-            if np.linalg.norm(vertex - np.array(new_polyp, dtype=np.float32)) < self.polyp_spacing:
-                return
+    def add_polyp(self, new_polyp: np.ndarray) -> None:
+        """Add a new polyp (vertex) to the mesh if spacing permits."""
 
-        # Add the new polyp
-        new_vertices = np.concatenate([vertices_np, np.array([new_polyp], dtype=np.float32)], axis=0)
-        new_idx = len(new_vertices) - 1
+        if np.any(np.linalg.norm(self.mesh.vertices - new_polyp, axis=1) < self.polyp_spacing):
+            return
 
-        indices_np = self.mesh["indices"].numpy()
-        distances = np.linalg.norm(vertices_np - np.array(new_polyp, dtype=np.float32), axis=1)
+        verts = np.vstack([self.mesh.vertices, new_polyp]).astype(np.float32)
+        new_idx = len(verts) - 1
+
+        distances = np.linalg.norm(verts[:-1] - new_polyp, axis=1)
         nearest = np.argsort(distances)[:3]
         new_tris = np.array(
             [
@@ -187,46 +157,52 @@ class SimpleP:
             dtype=np.int32,
         )
 
-        self.mesh["vertices"] = wp.array(new_vertices, dtype=wp.vec3f)
-        self.mesh["indices"] = wp.array(np.concatenate([indices_np, new_tris]), dtype=wp.vec3)
-
-        self.normals = wp.zeros(len(new_vertices), dtype=wp.vec3f)
-        self.launch_mesh_kernel()
+        faces = np.vstack([self.mesh.faces, new_tris]).astype(np.int32)
+        self.mesh = trimesh.Trimesh(vertices=verts, faces=faces, process=False)
+        self.update_wp_arrays()
 
     def growth_step(self) -> None:
         """Update state by growing the polyps and updating the mesh."""
-        vertices = self.mesh["vertices"]
-        normals = self.normals
 
-        # Create an array to store the growth amount for each polyp
-        growth_amount = wp.zeros(len(vertices), dtype=wp.float32)
-
-        # Launch the growth kernel to update the polyps
+        growth_amount = wp.zeros(len(self.verts_wp), dtype=wp.float32)
         wp.launch(
             self.growth_kernel,
-            dim=len(vertices),
-            inputs=[vertices, normals, growth_amount, self.polyp_spacing, len(vertices), self.resource_concentration, float(self.grid_shape[2])],
-        )  # Pass resource concentration and z_max (grid size)
-
+            dim=len(self.verts_wp),
+            inputs=[
+                self.verts_wp,
+                self.normals_wp,
+                growth_amount,
+                self.polyp_spacing,
+                len(self.verts_wp),
+                self.resource_concentration,
+                float(self.grid_shape[2]),
+            ],
+        )
         wp.synchronize()
-        verts_np = self.mesh["vertices"].numpy()
-        indices_np = self.mesh["indices"].numpy()
 
-        candidate = None
+        # Update the mesh from the Warp vertex array
+        self.mesh.vertices[:] = self.verts_wp.numpy()
+        self.mesh.vertex_normals = None  # Force recompute
+
+        # Ensure spacing between polyps
+        edges = self.mesh.edges_unique
+        lengths = self.mesh.edges_unique_length
+        candidate: np.ndarray | None = None
         max_gap = self.polyp_spacing
-
-        for tri in indices_np:
-            for i in range(3):
-                vi = tri[i]
-                vj = tri[(i + 1) % 3]
-                dist = np.linalg.norm(verts_np[vi] - verts_np[vj])
-                if dist > 2 * self.polyp_spacing and dist > max_gap:
-                    max_gap = dist
-                    candidate = (verts_np[vi] + verts_np[vj]) / 2.0
+        for edge, length in zip(edges, lengths, strict=False):
+            if length > 2 * self.polyp_spacing and length > max_gap:
+                v0, v1 = self.mesh.vertices[edge]
+                candidate = (v0 + v1) / 2.0
+                max_gap = float(length)
 
         if candidate is not None:
-            self.add_polyp(tuple(candidate))
+            self.add_polyp(candidate)
+        else:
+            # Mesh updated; refresh Warp arrays and normals
+            self.update_wp_arrays()
 
-    def reset(self) -> None:
-        """Reset Coral."""
+    def reset(self) -> None:  # noqa: D401 - Simple placeholder
+        """Reset coral state (currently a placeholder)."""
+
         pass
+


### PR DESCRIPTION
## Summary
- Rework `SimpleP` to manage its coral mesh using a `trimesh.Trimesh`
- Maintain Warp arrays for vertices, indices and normals to drive GPU kernels
- Update growth step logic to insert polyps using Trimesh edge queries

## Testing
- `pytest` *(fails: Warp CUDA error: Could not open libcuda.so; TypeError in ComputeLBM.update_mesh)*

------
https://chatgpt.com/codex/tasks/task_e_689e2a7565ec8323a4db2d76d55e77f7